### PR TITLE
Add deprecation notices for Language Translator v2

### DIFF
--- a/packages/language-translator-v2/README.md
+++ b/packages/language-translator-v2/README.md
@@ -1,5 +1,8 @@
 # Watson Language Translator V2 Package
 
+## Deprecation notice
+Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
+
 IBM Watson Language Translator translates text from one language to another. The service offers multiple domain-specific models that you can customize based on your unique terminology and language. Use Language Translator to take news from across the globe and present it in your language, communicate with your customers in their own language, and more.
 
 The Watson Language Translator V2 Package will contain the following entities. Find additional details at the API Reference by clicking the entity name.

--- a/packages/language-translator-v2/actions/create-model.js
+++ b/packages/language-translator-v2/actions/create-model.js
@@ -23,7 +23,7 @@ const extend = require('extend');
  * Uploads a TMX glossary file on top of a domain to customize a translation model.  Depending on the size of the file, training can range from minutes for a glossary to several hours for a large parallel corpus. Glossary files must be less than 10 MB. The cumulative file size of all uploaded glossary and corpus files is limited to 250 MB.
  *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
- * 
+ *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.
  * @param {string} [params.password] - The password used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/create-model.js
+++ b/packages/language-translator-v2/actions/create-model.js
@@ -22,6 +22,8 @@ const extend = require('extend');
  *
  * Uploads a TMX glossary file on top of a domain to customize a translation model.  Depending on the size of the file, training can range from minutes for a glossary to several hours for a large parallel corpus. Glossary files must be less than 10 MB. The cumulative file size of all uploaded glossary and corpus files is limited to 250 MB.
  *
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
+ * 
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.
  * @param {string} [params.password] - The password used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/delete-model.js
+++ b/packages/language-translator-v2/actions/delete-model.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * Delete model.
  *
  * Deletes a custom translation model.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.

--- a/packages/language-translator-v2/actions/delete-model.js
+++ b/packages/language-translator-v2/actions/delete-model.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * Delete model.
  *
  * Deletes a custom translation model.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/get-model.js
+++ b/packages/language-translator-v2/actions/get-model.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * Get model details.
  *
  * Gets information about a translation model, including training status for custom models.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/get-model.js
+++ b/packages/language-translator-v2/actions/get-model.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * Get model details.
  *
  * Gets information about a translation model, including training status for custom models.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.

--- a/packages/language-translator-v2/actions/identify.js
+++ b/packages/language-translator-v2/actions/identify.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * Identify language.
  *
  * Identifies the language of the input text.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/identify.js
+++ b/packages/language-translator-v2/actions/identify.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * Identify language.
  *
  * Identifies the language of the input text.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.

--- a/packages/language-translator-v2/actions/list-identifiable-languages.js
+++ b/packages/language-translator-v2/actions/list-identifiable-languages.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * List identifiable languages.
  *
  * Lists the languages that the service can identify. Returns the language code (for example, `en` for English or `es` for Spanish) and name of each language.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.

--- a/packages/language-translator-v2/actions/list-identifiable-languages.js
+++ b/packages/language-translator-v2/actions/list-identifiable-languages.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * List identifiable languages.
  *
  * Lists the languages that the service can identify. Returns the language code (for example, `en` for English or `es` for Spanish) and name of each language.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/list-models.js
+++ b/packages/language-translator-v2/actions/list-models.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * List models.
  *
  * Lists available translation models.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/list-models.js
+++ b/packages/language-translator-v2/actions/list-models.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * List models.
  *
  * Lists available translation models.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.

--- a/packages/language-translator-v2/actions/translate.js
+++ b/packages/language-translator-v2/actions/translate.js
@@ -21,6 +21,8 @@ const extend = require('extend');
  * Translate.
  *
  * Translates the input text from the source language to the target language.
+ * 
+ * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {string} [params.username] - The username used to authenticate with the service. Username and password credentials are only required to run your application locally or outside of Bluemix. When running on Bluemix, the credentials will be automatically loaded from the `VCAP_SERVICES` environment variable.

--- a/packages/language-translator-v2/actions/translate.js
+++ b/packages/language-translator-v2/actions/translate.js
@@ -21,7 +21,7 @@ const extend = require('extend');
  * Translate.
  *
  * Translates the input text from the source language to the target language.
- * 
+ *
  * @deprecated Language Translator v3 is now available. The v2 Language Translator API will no longer be available after July 31, 2018. To take advantage of the latest service enhancements, migrate to the v3 API. View the [Migrating to Language Translator v3](https://console.bluemix.net/docs/services/language-translator/migrating.html) page for more information.
  *
  * @param {Object} params - The parameters to send to the service.


### PR DESCRIPTION
This PR adds deprecation notices for Language Translator v2 in the README and v2 actions.

This will also be the final change for release 0.4.1.