### PR TITLE
docs: add deprecation notice to README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# openwhisk-sdk 
+# openwhisk-sdk - DEPRECATED
 [![Build Status](https://travis-ci.org/watson-developer-cloud/openwhisk-sdk.svg?branch=master)](http://travis-ci.org/watson-developer-cloud/openwhisk-sdk)
 [![CLA assistant](https://cla-assistant.io/readme/badge/watson-developer-cloud/openwhisk-sdk)](https://cla-assistant.io/watson-developer-cloud/openwhisk-sdk)
+
+** This SDK has been deprecated and is no longer being maintained. To access Watson from the Cloud Functions NodeJS Runtime, use the [Watson Node SDK](https://github.com/watson-developer-cloud/node-sdk).**
 
 The Watson openwhisk-sdk contains packages for each of the Watson Services to provide a convenient way to call the Watson APIs.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "watson-openwhisk-sdk",
   "version": "0.8.1",
-  "description": "SDK to run Watson services on IBM Cloud Functions (Based on Apache Openwhisk)",
+  "description": "SDK to run Watson services on IBM Cloud Functions (Based on Apache Openwhisk) - DEPRECATED",
   "main": "index.js",
   "scripts": {
     "test": "npm run test-unit && npm run test-integration",


### PR DESCRIPTION
Adds a note to the README stating that the package is deprecated. Also changing the description in the package.json file.

Once this is merged, I will officially "deprecate" the package on NPM.

cc @kemerson16 